### PR TITLE
Fix code scanning alert no. 85: Overly permissive regular expression range

### DIFF
--- a/FRONTEND/adminlte/js/codemirror/mode/css/css.js
+++ b/FRONTEND/adminlte/js/codemirror/mode/css/css.js
@@ -228,7 +228,7 @@ CodeMirror.defineMode("css", function(config, parserConfig) {
     if (type == "}" || type == "{") return popAndPass(type, stream, state);
     if (type == "(") return pushContext(state, stream, "parens");
 
-    if (type == "hash" && !/^#([0-9a-fA-f]{3,4}|[0-9a-fA-f]{6}|[0-9a-fA-f]{8})$/.test(stream.current())) {
+    if (type == "hash" && !/^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(stream.current())) {
       override += " error";
     } else if (type == "word") {
       wordAsValue(stream);


### PR DESCRIPTION
Fixes [https://github.com/PtPrashantTripathi/PortfolioTracker/security/code-scanning/85](https://github.com/PtPrashantTripathi/PortfolioTracker/security/code-scanning/85)

To fix the problem, we need to correct the overly permissive character range in the regular expression. Specifically, we should replace `A-f` with `A-F` to ensure that only the intended uppercase letters are matched. This change will prevent the regular expression from matching unintended characters while preserving the intended functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
